### PR TITLE
Putting back future bcs seems to be needed for past

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ dependencies = [
     'beautifulsoup4>=4.6.3',
     'lxml>=3.2.3,<4.4.0',
     'cssutils>=0.9.10',
+    'future',
     'six>=1.9.0'
 ]
 


### PR DESCRIPTION
This is because I ran into this error:
```
sushi-chef-african-storybook> ./chef.py --reset --thumbnails --token=/Users/ivan/.studiotoken
Traceback (most recent call last):
  File "./chef.py", line 22, in <module>
    from ricecooker.chefs import SushiChef
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/ricecooker/chefs.py", line 16, in <module>
    from .utils.jsontrees import read_tree_from_json
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/ricecooker/utils/jsontrees.py", line 5, in <module>
    from ricecooker.classes import files, nodes, questions
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/ricecooker/classes/files.py", line 25, in <module>
    from pressurecooker.subtitles import build_subtitle_converter_from_file
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/pressurecooker/subtitles.py", line 2, in <module>
    from pycaption import CaptionSet, WebVTTWriter
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/pycaption/__init__.py", line 1, in <module>
    from .base import (
  File "/Users/ivan/Projects/FLECode/sushi-chef-african-storybook/venv/lib/python3.7/site-packages/pycaption/base.py", line 1, in <module>
    from past.utils import old_div
```

Apparently the `future` package does not obey the "grep rule" and defines `builtins` and `past` module namespaces, see https://python-future.org/compatible_idioms.html

Locally pip installing future fixed the issue so I believe putting back the future depends will fix the above error.